### PR TITLE
Fix extension popup script parsing

### DIFF
--- a/popupInteractionHandler.js
+++ b/popupInteractionHandler.js
@@ -100,5 +100,3 @@ document.addEventListener('DOMContentLoaded', () => {
 
   chrome.runtime.onMessage.addListener(handleRuntimeMessage);
 });
-
-export { updateStatus, setButtonsEnabled, sendMessage, handleAutoClick, handleManualClick, handleExportClick, handleCancelClick, handleRuntimeMessage };


### PR DESCRIPTION
## Summary
- remove leftover ES module export from popup script

## Testing
- `node -c popupInteractionHandler.js`

------
https://chatgpt.com/codex/tasks/task_e_6855cf26929c83278dc94cda95ba997e