### PR TITLE
Fix background messaging for scrape workflow

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,12 +4,6 @@
   "short_name": "DataMiner",
   "version": "1.0.0",
   "description": "Scrape structured data from web pages and export to CSV.",
-  "icons": {
-    "16": "icons/icon16.png",
-    "32": "icons/icon32.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
-  },
   "permissions": [
     "storage",
     "activeTab",


### PR DESCRIPTION
## Summary
- wire popup messages to background and content scripts
- add detailed console logging for debugging
- handle cancel scrape and ensure responses
- strip unused icon references from manifest

## Testing
- `node --check commandRoutingExporter.js`
- `node --check scrapeSelectionManager.js`
- `node --check popupInteractionHandler.js`


------
https://chatgpt.com/codex/tasks/task_e_6855d4a9bd9483279cf6872e5e7a2b62