### PR TITLE
Improve selection feedback and error logging

### DIFF
--- a/popupInteractionHandler.js
+++ b/popupInteractionHandler.js
@@ -102,6 +102,9 @@ document.addEventListener('DOMContentLoaded', () => {
       case 'SCRAPE_ERROR':
         updateStatus(`Error: ${message.error}`, true);
         break;
+      case 'ELEMENT_ADDED':
+        updateStatus(`Added element #${message.count} for export.`);
+        break;
     }
   }
 

--- a/scrapeSelectionManager.js
+++ b/scrapeSelectionManager.js
@@ -58,7 +58,9 @@ const safeSendMessage = (message) => {
   console.log('content: sending', message);
   chrome.runtime.sendMessage(message, () => {
     if (chrome.runtime.lastError) {
-      console.error('chrome.runtime.sendMessage error:', chrome.runtime.lastError);
+      const errMsg = chrome.runtime.lastError && chrome.runtime.lastError.message ?
+        chrome.runtime.lastError.message : chrome.runtime.lastError;
+      console.error('chrome.runtime.sendMessage error:', errMsg);
     }
   });
 };
@@ -150,6 +152,8 @@ function beginManualSelection() {
     if (el) {
       selectedElements.push(el);
       highlightElement(el);
+      safeSendMessage({ type: 'ELEMENT_ADDED', count: selectedElements.length });
+      alert(`Element added to export list (#${selectedElements.length}).`);
       selectorTool.injectOverlay(onSelect);
     }
   }


### PR DESCRIPTION
## Summary
- clarify `chrome.runtime.sendMessage` errors
- notify popup when page selection is added
- alert user when element is added for export

## Testing
- `node --check scrapeSelectionManager.js`
- `node --check popupInteractionHandler.js`


------
https://chatgpt.com/codex/tasks/task_e_6855dae562b08327a941221ac640a72c