### PR TITLE
Fix overlay error and enable CSV export

### DIFF
--- a/commandRoutingExporter.js
+++ b/commandRoutingExporter.js
@@ -1,3 +1,5 @@
+importScripts('convertJsonToCsv.js');
+
 function notifyUser(message) {
   if (chrome.notifications && chrome.notifications.create) {
     chrome.notifications.create({

--- a/injectOverlaySelector.js
+++ b/injectOverlaySelector.js
@@ -5,6 +5,7 @@ let currentCallback = null;
 
 function updateOverlay() {
   requested = false;
+  if (!overlay) return;
   let target = lastTarget;
   if (!(target instanceof Element)) {
     target = target && target.parentElement;

--- a/scrapeSelectionManager.js
+++ b/scrapeSelectionManager.js
@@ -153,7 +153,7 @@ function beginManualSelection() {
       selectedElements.push(el);
       highlightElement(el);
       safeSendMessage({ type: 'ELEMENT_ADDED', count: selectedElements.length });
-      alert(`Element added to export list (#${selectedElements.length}).`);
+      alert('Element added for export');
       selectorTool.injectOverlay(onSelect);
     }
   }


### PR DESCRIPTION
## Summary
- prevent crash when overlay isn't ready by guarding `updateOverlay`
- show simplified alert when an element is added for export
- load CSV conversion utility in the background script so downloads work

## Testing
- `node --check injectOverlaySelector.js`
- `node --check scrapeSelectionManager.js`
- `node --check commandRoutingExporter.js`
- `node -e "const {convertJsonToCsv}=require('./convertJsonToCsv.js'); console.log(convertJsonToCsv([{url:'u',text:'t'}]));"`

------
https://chatgpt.com/codex/tasks/task_e_6855dcddb79883279c662ce7428bfb70