### PR TITLE
Fix manual selection status events

### DIFF
--- a/commandRoutingExporter.js
+++ b/commandRoutingExporter.js
@@ -154,6 +154,14 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
       console.error('SCRAPE_RESULT received with no data.');
       notifyUser('No data received for export.');
     }
+  } else if (
+    msg &&
+    sender &&
+    sender.tab &&
+    (msg.type === 'ELEMENT_ADDED' || msg.type === 'SCRAPE_ERROR' || msg.type === 'SCRAPE_CANCELED')
+  ) {
+    // Forward messages from content script to any extension pages (e.g., popup)
+    chrome.runtime.sendMessage(msg);
   }
 });
 


### PR DESCRIPTION
## Summary
- forward manual selection notifications from content script

## Testing
- `node --check commandRoutingExporter.js`
- `node --check scrapeSelectionManager.js`
- `node --check injectOverlaySelector.js`


------
https://chatgpt.com/codex/tasks/task_e_6855dea81fe08327be18b4b4991abb69