### PR TITLE
Fix heading selection and CSV export

### DIFF
--- a/commandRoutingExporter.js
+++ b/commandRoutingExporter.js
@@ -154,6 +154,8 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
       console.error('SCRAPE_RESULT received with no data.');
       notifyUser('No data received for export.');
     }
+    sendResponse({ ok: true });
+    return true;
   } else if (
     msg &&
     sender &&
@@ -162,6 +164,8 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
   ) {
     // Forward messages from content script to any extension pages (e.g., popup)
     chrome.runtime.sendMessage(msg);
+    sendResponse({ ok: true });
+    return true;
   }
 });
 

--- a/scrapeSelectionManager.js
+++ b/scrapeSelectionManager.js
@@ -151,9 +151,11 @@ function finalizeManualSelection() {
     safeSendMessage({ type: 'SCRAPE_ERROR', error: 'No elements selected.' });
     return;
   }
-  const data = selectedElements
+  const text = selectedElements
     .filter(el => el instanceof Element)
-    .map(el => ({ url, text: el.textContent.trim() }));
+    .map(el => el.textContent.trim())
+    .join(' ');
+  const data = [{ url, text }];
   clearHighlights();
   selectedElements = [];
   manualSelecting = false;
@@ -172,6 +174,12 @@ function beginManualSelection() {
       return;
     }
 
+    const tag = el.tagName && el.tagName.toLowerCase();
+    if (tag !== 'h1' && tag !== 'h2') {
+      alert('Please select only H1 or H2 headings.');
+      return;
+    }
+
     selectedElements.push(el);
     highlightElement(el);
     safeSendMessage({ type: 'ELEMENT_ADDED', count: selectedElements.length });
@@ -179,7 +187,7 @@ function beginManualSelection() {
 
     setTimeout(() => {
       selectorTool.injectOverlay(onSelect);
-    }, 100);
+    }, 300);
   }
 
   keyListener = (e) => {


### PR DESCRIPTION
## Summary
- restrict manual selection to headings and alert when added
- combine selected heading text into a single CSV row
- keep overlay stable while selecting
- respond to runtime messages so ports don't close early

## Testing
- `node -e "const {convertJsonToCsv}=require('./convertJsonToCsv.js');console.log(convertJsonToCsv([{url:'http://example.com',text:'hello'}]));"`

------
https://chatgpt.com/codex/tasks/task_e_6855e86b17c0832783487817eed2d9be