### PR TITLE
Fix missing icon download error

### DIFF
--- a/chromeNotificationsManager.js
+++ b/chromeNotificationsManager.js
@@ -7,7 +7,8 @@
     root.chromeNotificationsManager = factory();
   }
 }(typeof self !== 'undefined' ? self : this, function() {
-  const defaultIconUrl = chrome.runtime.getURL('icons/icon48.png');
+  // Default icon removed to avoid referencing missing assets
+  const defaultIconUrl = null;
   const clickListeners = [];
   const buttonClickListeners = [];
   const validTypes = new Set(['basic', 'image', 'list', 'progress']);
@@ -44,12 +45,18 @@
     }
 
     const notifId = id || generateNotificationId();
-    const options = { type, title, message, iconUrl };
+    const options = { type, title, message };
+    if (iconUrl || defaultIconUrl) {
+      options.iconUrl = iconUrl || defaultIconUrl;
+    }
     if (buttons.length) {
-      options.buttons = buttons.map(btn => ({
-        title: btn.title,
-        iconUrl: btn.iconUrl || defaultIconUrl
-      }));
+      options.buttons = buttons.map(btn => {
+        const btnOpts = { title: btn.title };
+        if (btn.iconUrl || defaultIconUrl) {
+          btnOpts.iconUrl = btn.iconUrl || defaultIconUrl;
+        }
+        return btnOpts;
+      });
     }
 
     return new Promise((resolve, reject) => {

--- a/commandRoutingExporter.js
+++ b/commandRoutingExporter.js
@@ -4,7 +4,6 @@ function notifyUser(message) {
   if (chrome.notifications && chrome.notifications.create) {
     chrome.notifications.create({
       type: 'basic',
-      iconUrl: 'icons/icon48.png',
       title: 'Data Miner',
       message: message
     });

--- a/extensionManifestConfig.json
+++ b/extensionManifestConfig.json
@@ -3,11 +3,6 @@
   "name": "Smart Data Scraper",
   "description": "Scrapes structured data from web pages and exports it to CSV via popup or context menu.",
   "version": "1.0.0",
-  "icons": {
-    "16": "icons/icon16.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
-  },
   "permissions": [
     "activeTab",
     "downloads",
@@ -23,12 +18,7 @@
   },
   "action": {
     "default_popup": "scrapePopupUI.html",
-    "default_title": "Smart Data Scraper",
-    "default_icon": {
-      "16": "icons/icon16.png",
-      "48": "icons/icon48.png",
-      "128": "icons/icon128.png"
-    }
+    "default_title": "Smart Data Scraper"
   },
   "options_ui": {
     "page": "filenameOptionsPage.html",


### PR DESCRIPTION
## Summary
- avoid referencing nonexistent icons in `commandRoutingExporter`
- make icons optional in notifications manager
- remove unused icon declarations from extension config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f2bd83c48327a90964db881f6cfd