### PR TITLE
Fix CSV export data validation

### DIFF
--- a/popupInteractionHandler.js
+++ b/popupInteractionHandler.js
@@ -19,13 +19,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function sendMessage(message) {
     return new Promise((resolve, reject) => {
-      console.log('popup: sending', message);
       chrome.runtime.sendMessage(message, response => {
         if (chrome.runtime.lastError) {
-          console.error('popup: sendMessage error', chrome.runtime.lastError);
           const msg = chrome.runtime.lastError.message || '';
-          if (msg.includes('Could not establish connection') || msg.includes('Receiving end does not exist')) {
-            reject(new Error('No content script found on this page. Reload and try again.'));
+          if (msg.includes('Receiving end does not exist')) {
+            reject(new Error('No active scrape session. Try reloading the page.'));
           } else {
             reject(chrome.runtime.lastError);
           }


### PR DESCRIPTION
## Summary
- validate `SCRAPE_RESULT` messages in the background script
- clarify popup error when there is no active scrape session

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855f42fb6ec8327823396e2304f72bc