### PR TITLE
Fix content script injection checks

### DIFF
--- a/commandRoutingExporter.js
+++ b/commandRoutingExporter.js
@@ -82,6 +82,7 @@ function dispatchScrapeToContentScript(mode, tabId, cb) {
             () => {
               if (chrome.runtime.lastError) {
                 console.error('Failed to inject content scripts', chrome.runtime.lastError);
+                notifyUser('Failed to inject content scripts. This page may not allow scripts.');
                 if (cb) cb({ success: false, error: 'Injection failed' });
               } else {
                 injectAndSend(id, message, true);
@@ -90,6 +91,7 @@ function dispatchScrapeToContentScript(mode, tabId, cb) {
           );
         } else {
           console.error('Failed to send message to tab', chrome.runtime.lastError);
+          notifyUser('Unable to communicate with page. Content script not found.');
           if (cb) cb({ success: false, error: 'Content script not found in tab.' });
         }
       } else {

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
     {
       "id": "data-miner-content",
       "matches": [
-        "<all_urls>"
+        "https://*/*",
+        "http://*/*"
       ],
       "js": [
         "injectOverlaySelector.js",


### PR DESCRIPTION
## Summary
- keep content scripts from loading on chrome:// pages by restricting URL patterns
- warn users when injecting scripts fails or messaging fails

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6855fa6741cc83279c5675ff8307b141