### PR TITLE
Fix manual selection UX blocker

### DIFF
--- a/scrapeSelectionManager.js
+++ b/scrapeSelectionManager.js
@@ -174,7 +174,6 @@ function beginManualSelection() {
     selectedElements.push(el);
     highlightElement(el);
     safeSendMessage({ type: 'ELEMENT_ADDED', count: selectedElements.length });
-    alert('Element added for export');
 
     setTimeout(() => {
       selectorTool.injectOverlay(onSelect);


### PR DESCRIPTION
## Summary
- avoid blocking alerts when selecting elements

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855fc844e988327b605ab990f9879f0