### PR TITLE
Fix overlay reinjection check

### DIFF
--- a/scrapeSelectionManager.js
+++ b/scrapeSelectionManager.js
@@ -174,10 +174,11 @@ function beginManualSelection() {
     selectedElements.push(el);
     highlightElement(el);
     safeSendMessage({ type: 'ELEMENT_ADDED', count: selectedElements.length });
-    alert('Element added for export');
 
     setTimeout(() => {
-      selectorTool.injectOverlay(onSelect);
+      if (manualSelecting) {
+        selectorTool.injectOverlay(onSelect);
+      }
     }, 300);
   }
 


### PR DESCRIPTION
## Summary
- prevent reinjecting overlay if manual selection was cancelled
- remove leftover alert message

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855fcd798e88327b9a727b274683fa3