### PR TITLE
Fix overlay reactivation and remove alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In auto mode the extension collects only `<h1>` headings from the current page a
 3. Choose **Auto Detect & Export** to automatically capture all `<h1>` and `<h2>` elements, or select **Select Data to Export** to manually pick elements.
 4. When manual selection mode is active:
    - Focus returns to the page and the **Export to CSV** button in the popup is disabled.
-   - Click each `<h1>` or `<h2>` you want to export. After each click you'll see a short alert confirming the element was added.
+   - Click each `<h1>` or `<h2>` you want to export. After each click a message in the popup confirms the element was added.
    - Press **Enter** while still focused on the page to finalize your selection and start the CSV download.
    - Press **Escape** if you want to cancel.
 

--- a/scrapeSelectionManager.js
+++ b/scrapeSelectionManager.js
@@ -160,14 +160,13 @@ function beginManualSelection() {
   selectionHighlights = [];
 
   function onSelect(el) {
-    if (!el || !(el instanceof Element)) {
-      alert('Invalid element selected. Try clicking on a visible element.');
-      return;
-    }
-
-    const tag = el.tagName && el.tagName.toLowerCase();
-    if (tag !== 'h1' && tag !== 'h2') {
-      alert('Please select only H1 or H2 headings.');
+    if (!el || !(el instanceof Element) || !['h1', 'h2'].includes(el.tagName.toLowerCase())) {
+      safeSendMessage({ type: 'SCRAPE_ERROR', error: 'Only H1 or H2 elements are supported.' });
+      setTimeout(() => {
+        if (manualSelecting) {
+          selectorTool.injectOverlay(onSelect);
+        }
+      }, 300);
       return;
     }
 


### PR DESCRIPTION
## Summary
- provide runtime feedback for invalid manual selections
- retry overlay injection after invalid element clicks
- update README manual selection instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855feb237488327918e12fca7bf76e5